### PR TITLE
fix panux-builder chart

### DIFF
--- a/helm/panux-builder/templates/buildmanager-dep.yaml
+++ b/helm/panux-builder/templates/buildmanager-dep.yaml
@@ -18,11 +18,11 @@ spec:
       labels:
         app: panux-builder-buildmanager
         release: {{ .Release.Name }}
-    volumes:
-    - name: buildmanager-authkeys
-      secret:
-        secretName: {{ .Values.auth }}
     spec:
+      volumes:
+        - name: buildmanager-authkeys
+          secret:
+            secretName: {{ .Values.auth }}
       containers:
         - name: buildmanager
           image: "{{ .Values.images.buildmanager.repository }}"

--- a/helm/panux-builder/templates/pbuild-dep.yaml
+++ b/helm/panux-builder/templates/pbuild-dep.yaml
@@ -18,14 +18,14 @@ spec:
       labels:
         app: panux-builder-pbuild
         release: {{ .Release.Name }}
-    volumes:
-      - name: pbuild-srv
-        hostPath:
-          path: /srv/pbuild
-      - name: pbuild-authkeys
-        secret:
-          secretName: {{ .Values.auth }}
     spec:
+      volumes:
+        - name: pbuild-srv
+          hostPath:
+            path: /srv/pbuild
+        - name: pbuild-authkeys
+          secret:
+            secretName: {{ .Values.auth }}
       containers:
         - name: pbuild
           image: "{{ .Values.images.pbuild.repository }}"

--- a/helm/panux-builder/templates/pbuild-svc.yaml
+++ b/helm/panux-builder/templates/pbuild-svc.yaml
@@ -13,7 +13,7 @@ spec:
     - port: 80
       targetPort: 8065
       protocol: TCP
-      name: 80
+      name: http
   selector:
     app: panux-builder-pbuild
     release: {{ .Release.Name }}


### PR DESCRIPTION
There were several spec issues, most notably

- the `volumes` field should be under the pod's spec field rather than under `spec.template`
- the name of the service should be a string